### PR TITLE
check-pypy should just call check with the right PYTHON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ check:: build
 	$(RUNTEST) fastimport.tests.test_suite
 
 check-pypy:: clean
-	$(MAKE) check-noextensions PYTHON=pypy
+	$(MAKE) check PYTHON=pypy
 
 check-all: check check-pypy
 


### PR DESCRIPTION
not sure why it's calling check-noextensions which does not exist, copy/paste from an other project with native extensions?
