### PR TITLE
Get handlers from class object using getattr() for possible inheritance

### DIFF
--- a/fastimport/processor.py
+++ b/fastimport/processor.py
@@ -67,7 +67,7 @@ class ImportProcessor(object):
         self.pre_process()
         for cmd in command_iter():
             try:
-                handler = self.__class__.__dict__[cmd.name + "_handler"]
+                handler = getattr(self.__class__, cmd.name + "_handler")
             except KeyError:
                 raise errors.MissingHandler(cmd.name)
             else:
@@ -150,7 +150,7 @@ class CommitHandler(object):
         self.pre_process_files()
         for fc in self.command.iter_files():
             try:
-                handler = self.__class__.__dict__[fc.name[4:] + "_handler"]
+                handler = getattr(self.__class__, fc.name[4:] + "_handler")
             except KeyError:
                 raise errors.MissingHandler(fc.name)
             else:


### PR DESCRIPTION
Issue #6: **dict** stores only class' local variables and therefore it
can't find the handlers defined in the inherited classes.
