### PR TITLE
Fix for concat exception when mark is integer

### DIFF
--- a/fastimport/commands.py
+++ b/fastimport/commands.py
@@ -162,10 +162,13 @@ class CommitCommand(ImportCommand):
         self.lineno = lineno
         self._binary = [b'file_iter']
         # Provide a unique id in case the mark is missing
-        if mark is None:
+        if self.mark is None:
             self.id = b'@' + ('%d' % lineno).encode('utf-8')
         else:
-            self.id = b':' + mark
+            if isinstance(self.mark, (int)):
+                self.id = b':' + str(self.mark).encode('utf-8')
+            else:
+                self.id = b':' + self.mark
 
     def copy(self, **kwargs):
         if not isinstance(self.file_iter, list):
@@ -194,7 +197,11 @@ class CommitCommand(ImportCommand):
         if self.mark is None:
             mark_line = b''
         else:
-            mark_line = b'\nmark :' + self.mark
+            if isinstance(self.mark, (int)):
+                mark_line = b'\nmark :' + str(self.mark).encode('utf-8')
+            else:
+                mark_line = b'\nmark :' + self.mark
+
         if self.author is None:
             author_section = b''
         else:

--- a/fastimport/tests/test_commands.py
+++ b/fastimport/tests/test_commands.py
@@ -205,6 +205,27 @@ class TestCommitDisplay(TestCase):
             b"property planet 5 world",
             repr_bytes(c))
 
+    def test_commit_with_int_mark(self):
+        # user tuple is (name, email, secs-since-epoch, secs-offset-from-utc)
+        committer = (b'Joe Wong', b'joe@example.com', 1234567890, -6 * 3600)
+        properties = {
+            u'greeting':  u'hello',
+            u'planet':    u'world',
+            }
+        c = commands.CommitCommand(b'refs/heads/master', 123, None,
+            committer, b'release v1.0', b':aaa', None, None,
+            properties=properties)
+        self.assertEqual(
+            b"commit refs/heads/master\n"
+            b"mark :123\n"
+            b"committer Joe Wong <joe@example.com> 1234567890 -0600\n"
+            b"data 12\n"
+            b"release v1.0\n"
+            b"from :aaa\n"
+            b"property greeting 5 hello\n"
+            b"property planet 5 world",
+            repr_bytes(c))
+
 class TestCommitCopy(TestCase):
 
     def setUp(self):
@@ -227,7 +248,6 @@ class TestCommitCopy(TestCase):
 
     def test_replace_attr(self):
         c2 = self.c.copy(mark=b'ccc')
-
         self.assertEqual(
             repr_bytes(self.c).replace(b'mark :bbb', b'mark :ccc'),
             repr_bytes(c2)


### PR DESCRIPTION
When trying to export from a bzr repo I encountered an exception

`cannot concatenate 'str' and 'int' objects`

due to the revision ids being integers. The attached pull request fixes this issue. I have also added tests for commits of this type.