### PR TITLE
Import our own modules using relative pathing

### DIFF
--- a/fastimport/commands.py
+++ b/fastimport/commands.py
@@ -24,7 +24,7 @@ import re
 import stat
 import sys
 
-from fastimport.helpers import (
+from .helpers import (
     newobject as object,
     utf8_bytes_string,
     repr_bytes,

--- a/fastimport/dates.py
+++ b/fastimport/dates.py
@@ -24,7 +24,7 @@ timestamp,timezone where
 """
 import time
 
-from fastimport import errors
+from . import errors
 
 
 def parse_raw(s, lineno=0):

--- a/fastimport/parser.py
+++ b/fastimport/parser.py
@@ -164,12 +164,12 @@ import re
 import sys
 import codecs
 
-from fastimport import (
+from . import (
     commands,
     dates,
     errors,
     )
-from fastimport.helpers import (
+from .helpers import (
     newobject as object,
     utf8_bytes_string,
     )

--- a/fastimport/processor.py
+++ b/fastimport/processor.py
@@ -32,8 +32,8 @@ processors package for examples.
 import sys
 import time
 
-from fastimport import errors
-from fastimport.helpers import newobject as object
+from . import errors
+from .helpers import newobject as object
 
 
 class ImportProcessor(object):

--- a/fastimport/processors/filter_processor.py
+++ b/fastimport/processors/filter_processor.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Import processor that filters the input (and doesn't import)."""
-from fastimport import (
+from .. import (
     commands,
     helpers,
     processor,

--- a/fastimport/processors/info_processor.py
+++ b/fastimport/processors/info_processor.py
@@ -18,15 +18,13 @@
 from __future__ import absolute_import
 
 from .. import (
+    commands,
+    processor,
     reftracker,
     )
 from ..helpers import (
     invert_dict,
     invert_dictset,
-    )
-from fastimport import (
-    commands,
-    processor,
     )
 import stat
 

--- a/fastimport/processors/query_processor.py
+++ b/fastimport/processors/query_processor.py
@@ -17,7 +17,7 @@
 from __future__ import print_function
 
 
-from fastimport import (
+from .. import (
     commands,
     processor,
     )


### PR DESCRIPTION
This allows python-fastimport to be embedded as vendor code within
other modules.
Although python disallows a dash in a module name so I called it
vendor/python_fastimport.