### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Operating System :: POSIX",
     "Topic :: Software Development :: Version Control",
 ]
-description-file = "README.md"
+readme = "README.md"
 requires-python = ">=3.7"
 dynamic = ["version"]
 dependencies = []


### PR DESCRIPTION
`description-file` is not a valid `project` property. It's called `readme`

Fixes error:

````
poetry add git+https://github.com/jelmer/python-fastimport
[....]
  File "C:\Users\Henryk\AppData\Local\Temp\tmph06huca3\.venv\lib\site-packages\setuptools\config\pyprojecttoml.py", line 51, in validate
    raise ValueError(f"{error}\n{summary}") from None
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must not contain {'description-file'} properties
````